### PR TITLE
Updated American flag asset serving

### DIFF
--- a/server/server/static/main.css
+++ b/server/server/static/main.css
@@ -132,7 +132,7 @@ a.btn.btn-outline-danger.btn-lg {
 }
 
 #mainPicture {
-  background: url("../static/imgs/AmericanFlag.jpg") no-repeat center center
+  background: url("https://i.imgur.com/zzfoIahr.jpg") no-repeat center center
     fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;


### PR DESCRIPTION
Compressed the image to 33% of it's current size, uploaded to imgur instead of having it served from your HTTP server.

First impression of the website, important that it isn't loading for seconds(!!!).